### PR TITLE
Change search get resource method

### DIFF
--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -119,7 +119,7 @@ module Avo
     end
 
     def belongs_to_field
-      fields = ::Avo::App.get_resource_by_model_name(params[:via_reflection_class]).get_field_definitions
+      fields = ::Avo::App.get_resource_by_name(params[:via_reflection_class]).get_field_definitions
       fields.find { |f| f.id.to_s == params[:via_association_id] }
     end
   end


### PR DESCRIPTION
Search method uses `get_resource_by_model_name` to identify the resource, which leads to the known bug of just grabbing the first of all the resources that use a given model name. Overriding for an exact match of the searched resource to see how it fares